### PR TITLE
Make sure ping uses ipv4 when $TESTPROTO equals -4

### DIFF
--- a/betterspeedtest.sh
+++ b/betterspeedtest.sh
@@ -114,9 +114,9 @@ start_pings() {
   # Start Ping
   if [ $TESTPROTO -eq "-4" ]
   then
-    ping  $PINGHOST > $PINGFILE &
+    "${PING4}"  $PINGHOST > $PINGFILE &
   else
-    ping6 $PINGHOST > $PINGFILE &
+    "${PING6}"	$PINGHOST > $PINGFILE &
   fi
   ping_pid=$!
   # echo "Ping PID: $ping_pid"
@@ -186,6 +186,11 @@ measure_direction() {
 # set an initial values for defaults
 TESTHOST="netperf.bufferbloat.net"
 TESTDUR="60"
+
+PING4=ping
+command -v ping4 > /dev/null 2>&1 && PING4=ping4
+PING6=ping6
+
 PINGHOST="gstatic.com"
 MAXSESSIONS="5"
 TESTPROTO="-4"

--- a/idlelatency.sh
+++ b/idlelatency.sh
@@ -108,9 +108,9 @@ start_pings() {
   # Start Ping
   if [ $TESTPROTO -eq "-4" ]
   then
-    ping  $PINGHOST > $PINGFILE &
+    "${PING4}" $PINGHOST > $PINGFILE &
   else
-    ping6 $PINGHOST > $PINGFILE &
+    "${PING6}" $PINGHOST > $PINGFILE &
   fi
   ping_pid=$!
   # echo "Ping PID: $ping_pid"
@@ -127,6 +127,11 @@ start_pings() {
 
 # set an initial values for defaults
 TESTDUR="60"
+
+PING4=ping
+command -v ping4 > /dev/null 2>&1 && PING4=ping4
+PING6=ping6
+
 PINGHOST="gstatic.com"
 TESTPROTO="-4"
 

--- a/netperfrunner.sh
+++ b/netperfrunner.sh
@@ -72,6 +72,11 @@ summarize_pings() {
 # set an initial values for defaults
 TESTHOST="netperf.bufferbloat.net"
 TESTDUR="60"
+
+PING4=ping
+command -v ping4 > /dev/null 2>&1 && PING4=ping4
+PING6=ping6
+
 PINGHOST="gstatic.com"
 MAXSESSIONS=4
 TESTPROTO=-4
@@ -132,9 +137,9 @@ echo "$DATE Testing $TESTHOST ($PROTO) with $MAXSESSIONS streams down and up whi
 # Start Ping
 if [ $TESTPROTO -eq "-4" ]
 then
-	ping $PINGHOST > $PINGFILE &
+	"${PING4}" $PINGHOST > $PINGFILE &
 else
-	ping6 $PINGHOST > $PINGFILE &
+	"${PING6}" $PINGHOST > $PINGFILE &
 fi
 ping_pid=$!
 # echo "Ping PID: $ping_pid"


### PR DESCRIPTION
The ping command on some systems will default to using ipv6 if a
hostname resolves to both ipv4 and ipv6 addresses.