### PR TITLE
Fix for POSIX compliant shell

### DIFF
--- a/betterspeedtest.sh
+++ b/betterspeedtest.sh
@@ -67,7 +67,7 @@ summarize_pings() {
 print_dots() {
   while : ; do
     printf "."
-    sleep 1s
+    sleep 1
   done
 }
 


### PR DESCRIPTION
On some POSIX compliant sh shells, sleep command doesn't accept args with s, m, h
This fixes running the script in FreeBSD