### PR TITLE
Add git-http package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ The easiest way to do this is to use ssh into the router and enter these command
 
 ```
 opkg update
-opkg install netperf
-opkg install git
+opkg install netperf git git-http
 cd /usr/lib
 git clone https://github.com/richb-hanover/OpenWrtScripts.git
 ```


### PR DESCRIPTION
Adding 'git-http' package installation to avoid error: 
`git: 'remote-https' is not a git command. See 'git --help'`